### PR TITLE
Adds apt update before installing packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Last tested on ChromeOS & ChromeOS Flex (105.0.5195.112), Linux Development Envi
 Installing ansible:
 
 ```shell
+sudo apt update
 sudo apt install ansible -y
 ```
 


### PR DESCRIPTION
When installing I noticed that I had to run 'sudo apt update' before the installation.
Might be worthwhile adding that extra command to the README.